### PR TITLE
fix: make socket more race-resilient, make tests more readable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -182,6 +182,15 @@
       "integrity": "sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g==",
       "dev": true
     },
+    "@types/chai-subset": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
+    },
     "@types/mocha": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
@@ -1351,6 +1360,12 @@
         "pathval": "^1.0.0",
         "type-detect": "^4.0.0"
       }
+    },
+    "chai-subset": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.6.0.tgz",
+      "integrity": "sha1-pdDKFOMpp5WW7XAFi2ZGvWmIz+k=",
+      "dev": true
     },
     "chainsaw": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:unit": "karma start test/karma.conf.js --single-run",
     "test:lint": "tslint -t verbose --project tsconfig.json \"src/**/*.ts\"",
     "test:watch": "karma start test/karma.conf.js --no-single-run",
-    "fmt": "prettier --write \"**/*.{ts,js}\" && npm run -s test:lint -- --fix",
+    "fmt": "prettier --write \"src/**/*.{ts,js}\" && npm run -s test:lint -- --fix",
     "prepare": "tsc"
   },
   "repository": {
@@ -27,10 +27,12 @@
   "homepage": "https://github.com/mixer/postmessage-rpc#readme",
   "devDependencies": {
     "@types/chai": "^4.1.4",
+    "@types/chai-subset": "^1.3.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.9.4",
     "@types/sinon": "^5.0.2",
     "chai": "^4.1.2",
+    "chai-subset": "^1.6.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "karma": "^3.0.0",
     "karma-browserstack-launcher": "^1.3.0",

--- a/src/marbles.test.ts
+++ b/src/marbles.test.ts
@@ -1,0 +1,168 @@
+import { expect, use } from 'chai';
+import { RPC } from './rpc';
+import { IMessageEvent, RPCMessage } from './types';
+
+// tslint:disable-next-line
+use(require('chai-subset'));
+
+/**
+ * Function that returns a delay of the requested number of milliseconds.
+ */
+export const delay = (duration: number = 1) =>
+  new Promise(resolve => setTimeout(resolve, duration));
+
+/**
+ * Action defines the assertion to run in the test definition
+ */
+export const enum Action {
+  Send,
+  Handler,
+  Receive,
+  IsReady,
+}
+
+/**
+ * Definition is passed to the IMarbleTest to define what checks to run
+ * at each point. In order:
+ *
+ *  1. Send a method. From the RPC, it should have a method name and body.
+ *  2. Asserts that the RPC is in the ready state at the given time.
+ *  3. Asserts that we receive something that matches the given subset
+ *  4. Asserts that we receive something that deep equals the given object
+ *  5. Asserts that we receive something, and passes the message to the test
+ *     function.
+ */
+export type Definition =
+  | { action: Action.Send; method?: string; data: any }
+  | { action: Action.IsReady; value: boolean }
+  | { action: Action.Receive; subset: any }
+  | { action: Action.Receive; object: any }
+  | { action: Action.Receive; tester: (r: RPCMessage<any>) => void };
+
+function testMethod(charDef: string, def: Definition, message: RPCMessage<any> | undefined) {
+  if (def.action !== Action.Receive) {
+    return;
+  }
+
+  if (!message) {
+    throw new Error(`Expected to get reply for definition ${charDef}, but we didn't`);
+  }
+
+  if ('subset' in def) {
+    expect(message).to.containSubset(def.subset);
+  } else if ('object' in def) {
+    expect(message).to.deep.equal(def.object, `expected objects in def ${charDef} to be equal`);
+  } else {
+    def.tester(message);
+  }
+}
+
+/**
+ * Options passed into testMarbles.
+ */
+export interface IMarbleTest {
+  /**
+   * Marble test for RPC instance. E.g. `--a-b-c`. Dashes are "no ops",
+   * letters match up to assertions in the `definitions` object.
+   */
+  rpcInstance: string;
+
+  /**
+   * Marble test for "remote window". E.g. `--a-b-c`. Dashes are "no ops",
+   * letters match up to assertions in the `definitions` object.
+   */
+  remoteContx: string;
+
+  /**
+   * Assertions matching up to the marble test.
+   */
+  definitions: { [char: string]: Definition };
+
+  /**
+   * Handler methods to attach to the marbles.
+   */
+  handlers?: { [method: string]: (data: any) => any };
+}
+
+/**
+ * rxjs-style marble sequence tests.
+ */
+export async function testMarbles({
+  rpcInstance,
+  remoteContx,
+  definitions,
+  handlers,
+}: IMarbleTest) {
+  const messagesSentToRemote: Array<RPCMessage<any>> = [];
+  const messagesReceivedByRPC: Array<RPCMessage<any>> = [];
+
+  let sendMessage: null | ((ev: IMessageEvent) => void) = null;
+  let toreDown = false;
+  let isReady = false;
+
+  const rpc = new RPC({
+    target: { postMessage: (data: any) => messagesSentToRemote.push(JSON.parse(data)) },
+    receiver: {
+      readMessages: callback => {
+        sendMessage = event => callback({ data: JSON.stringify(event.data), origin: event.origin });
+        return () => (toreDown = true);
+      },
+    },
+    origin: 'example.com',
+    serviceId: 'foo',
+  });
+
+  rpc.on('recvData', p => messagesReceivedByRPC.push(p));
+  rpc.on('isReady', () => (isReady = true));
+
+  while (rpcInstance.length < remoteContx.length) {
+    rpcInstance += '-';
+  }
+  while (remoteContx.length < rpcInstance.length) {
+    remoteContx += '-';
+  }
+
+  if (handlers) {
+    for (const key of Object.keys(handlers)) {
+      rpc.expose(key, handlers[key]);
+    }
+  }
+
+  for (let i = 0; i < rpcInstance.length; i++) {
+    if (rpcInstance[i] !== '-') {
+      const def = definitions[rpcInstance[i]];
+      if (!def) {
+        throw new Error(`Unknown action ${rpcInstance[i]}`);
+      }
+
+      if (def.action === Action.Send) {
+        rpc.call(def.method!, def.data, false);
+      } else if (def.action === Action.Receive) {
+        testMethod(rpcInstance[i], def, messagesReceivedByRPC.shift());
+      } else if (def.action === Action.IsReady) {
+        expect(isReady).to.equal(
+          def.value,
+          `expected the rpc.ready=${def.value} by ${rpcInstance[i]}, but it was not`,
+        );
+      }
+    }
+
+    if (remoteContx[i] !== '-') {
+      const def = definitions[remoteContx[i]];
+      if (!def) {
+        throw new Error(`Unknown action ${remoteContx[i]}`);
+      }
+
+      if (def.action === Action.Send) {
+        sendMessage!(def.data);
+      } else {
+        testMethod(rpcInstance[i], def, messagesSentToRemote.shift());
+      }
+    }
+
+    await delay();
+  }
+
+  rpc.destroy();
+  expect(toreDown).to.be.true;
+}

--- a/src/reorder.ts
+++ b/src/reorder.ts
@@ -15,14 +15,18 @@ export class Reorder {
   private queue: Array<RPCMessageWithCounter<any>> = [];
 
   /**
+   * Resets the queue and call counter to the given value.
+   */
+  public reset(counter: number) {
+    this.lastSequentialCall = counter - 1;
+    this.queue = [];
+  }
+
+  /**
    * Appends a message to the reorder queue. Returns all messages which
    * are good to send out.
    */
   public append(packet: RPCMessageWithCounter<any>): Array<RPCMessageWithCounter<any>> {
-    if (packet.type === 'method' && packet.method === 'ready') {
-      this.lastSequentialCall = packet.counter - 1;
-    }
-
     if (packet.counter <= this.lastSequentialCall + 1) {
       const list = [packet];
       this.lastSequentialCall = packet.counter;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     ],
     "types": [
       "mocha",
-      "node"
+      "node",
+      "chai-subset"
     ]
   },
   "include": [


### PR DESCRIPTION
While debugging with @fylock we noticed a certain race happening when
the socket first sets up if the remote is not quite ready for data yet. The
`ready` calls were supposed to solve this, but they didn't do so in all case.
This fixes that; "ready" is now a full request/response. Both sides
send it when they're ready. The first person to send their ready will
generally not receive a reply because the other page is still loading.
The second person will. Now, the "ready" reset happens both when the frame
receives a ready call *and* its reply.

I also refactored tests significantly. They were becoming extremely hard to
follow and write previously; I took inspiration from rxjs marbles and created
a sequence-based test runner. The test runner code is ugly (whatever) but
the tests are way easier to read, write, and reason about now.